### PR TITLE
Load course modules in courseService

### DIFF
--- a/src/pages/app/Dashboard.jsx
+++ b/src/pages/app/Dashboard.jsx
@@ -40,7 +40,7 @@ const Dashboard = () => {
 
   // Calculate course progress based on completed modules
   function getCourseProgress(course) {
-    const modules = Array.isArray(course.modules) ? course.modules : [];
+    const modules = course.modules || [];
     if (modules.length === 0) return 0;
 
     const progressForCourse = userProgress[course.id] || {};

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -3,9 +3,21 @@ import { collection, getDocs } from "firebase/firestore";
 
 export async function getCourses() {
   const snapshot = await getDocs(collection(db, "courses"));
-  return snapshot.docs.map(doc => ({
-    id: doc.id,
-    ...doc.data(),
-    completed: false,
-  }));
+  const courses = [];
+  for (const docSnap of snapshot.docs) {
+    const modulesSnap = await getDocs(
+      collection(db, "courses", docSnap.id, "modules")
+    );
+    const modules = modulesSnap.docs.map(mod => ({
+      id: mod.id,
+      ...mod.data(),
+    }));
+    courses.push({
+      id: docSnap.id,
+      ...docSnap.data(),
+      modules,
+      completed: false,
+    });
+  }
+  return courses;
 }


### PR DESCRIPTION
## Summary
- include modules when fetching courses
- rely on `course.modules` in dashboard progress calculation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bcca6cb44832daec92f5e99dc89be