### PR TITLE
Add error logging for all catch blocks

### DIFF
--- a/src/pages/app/Profile.jsx
+++ b/src/pages/app/Profile.jsx
@@ -50,8 +50,9 @@ const Profile = () => {
           });
           setCompletedCourses(count);
         }
-      } catch {
-        setError("Failed to load profile.");
+        } catch (err) {
+          console.error(err);
+          setError("Failed to load profile.");
       } finally {
         setLoading(false);
       }
@@ -78,7 +79,8 @@ const Profile = () => {
       setUser(updatedProfile);
       setForm(updatedProfile);
       setDob(updatedProfile && updatedProfile.dob ? new Date(updatedProfile.dob) : null);
-    } catch {
+    } catch (err) {
+      console.error(err);
       setError("Failed to update profile.");
     } finally {
       setLoading(false);

--- a/src/pages/auth/CompleteProfile.jsx
+++ b/src/pages/auth/CompleteProfile.jsx
@@ -40,8 +40,9 @@ const CompleteProfile = () => {
             return; 
           }
         }
-      } catch {
-        // Fail silently, let user fill the form
+        } catch (err) {
+          console.error(err);
+          // Fail silently, let user fill the form
       }
       setLoading(false);
     }
@@ -77,7 +78,8 @@ const CompleteProfile = () => {
         ...updatedForm,
       });
       navigate("/dashboard");
-    } catch {
+    } catch (err) {
+      console.error(err);
       setError("Failed to update profile.");
     }
     setSaving(false);

--- a/src/services/userProfileCheck.js
+++ b/src/services/userProfileCheck.js
@@ -28,7 +28,8 @@ export default function useProfileCheck() {
           );
           setIsComplete(allFilled);
         }
-      } catch {
+      } catch (err) {
+        console.error(err);
         setIsComplete(false);
       }
       setLoading(false);


### PR DESCRIPTION
## Summary
- log caught errors in profile components and service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bdfbcee20832d9ee8482d4412fab1