### PR TITLE
Fix completed course count

### DIFF
--- a/src/components/ProfileStats.jsx
+++ b/src/components/ProfileStats.jsx
@@ -10,7 +10,7 @@ const ProfileStats = ({ longestStreak, completedCourses }) => {
       </div>
       <div>
         <span className="font-semibold">Completed {courseLabel}: </span>
-        <span className="underline text-[#bfc6ff]">{completedCourses} {courseLabel}</span>
+        <span className="underline text-[#bfc6ff]">{completedCourses}</span>
       </div>
     </div>
   );

--- a/src/pages/app/Profile.jsx
+++ b/src/pages/app/Profile.jsx
@@ -30,8 +30,9 @@ const Profile = () => {
         setUser(profile);
         setForm(profile);
         setDob(profile && profile.dob ? new Date(profile.dob) : null);
+        setCompletedCourses(profile?.completedCourses?.length || 0);
 
-        if (authUser) {
+        if (authUser && (!profile?.completedCourses || profile.completedCourses.length === 0)) {
           const allCourses = await getCourses();
           const allProgress = await getAllUserProgress(authUser.uid);
 
@@ -39,13 +40,13 @@ const Profile = () => {
           allCourses.forEach(course => {
             const modules = course.modules || [];
             const progress = allProgress[course.id] || {};
-          const allModulesCompleted =
-            modules.length > 0 &&
-            modules.every(
-              (mod) =>
-                progress[mod.id]?.lessonCompleted ||
-                progress[mod.id]?.exerciseCompleted
-            );
+            const allModulesCompleted =
+              modules.length > 0 &&
+              modules.every(
+                (mod) =>
+                  progress[mod.id]?.lessonCompleted ||
+                  progress[mod.id]?.exerciseCompleted
+              );
             if (allModulesCompleted) count++;
           });
           setCompletedCourses(count);


### PR DESCRIPTION
## Summary
- display profile `completedCourses` length correctly
- fall back to progress calculation when profile field missing
- show cleaner course completion label

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684be0772200832d91f8782af3f967a1