### PR TITLE
Add profile completion checks

### DIFF
--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -17,6 +17,24 @@ export async function updateUserProfile(data) {
   if (!user) throw new Error("No user logged in");
   const docRef = doc(db, "users", user.uid);
   await updateDoc(docRef, data);
+
+  const updatedSnap = await getDoc(docRef);
+  if (updatedSnap.exists()) {
+    const profile = updatedSnap.data();
+    const requiredFields = [
+      profile.firstName,
+      profile.lastName,
+      profile.country,
+      profile.dob,
+      profile.institution
+    ];
+
+    const isComplete = requiredFields.every(Boolean);
+    if (isComplete && !profile.profileComplete) {
+      await updateDoc(docRef, { profileComplete: true });
+      await unlockAchievement(user.uid, "profile-complete");
+    }
+  }
 }
 
 // Calculate level from experience


### PR DESCRIPTION
## Summary
- update `updateUserProfile` to check required profile fields
- set `profileComplete` flag and unlock achievement when finished

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ccc10e964832dbd1b4d6de70da742