### PR TITLE
Trigger achievement check on lesson completion

### DIFF
--- a/src/services/userProgressService.js
+++ b/src/services/userProgressService.js
@@ -1,5 +1,6 @@
 import { db } from "./firebase";
 import { doc, setDoc, getDoc, getDocs, collection } from "firebase/firestore";
+import { checkLessonAchievements } from "./achievementService";
 
 // Mark both lesson and exercise as completed
 export async function markModuleCompleted(userId, courseId, moduleId) {
@@ -12,6 +13,7 @@ export async function markModuleCompleted(userId, courseId, moduleId) {
     },
     { merge: true }
   );
+  await checkLessonAchievements(userId);
 }
 
 // Mark only the lesson portion as completed
@@ -24,6 +26,7 @@ export async function markLessonCompleted(userId, courseId, moduleId) {
     },
     { merge: true }
   );
+  await checkLessonAchievements(userId);
 }
 
 // Get all completed modules for a course for a user


### PR DESCRIPTION
## Summary
- call `checkLessonAchievements` whenever a lesson or module is completed
- import the achievement helper in the progress service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ccd22c0a4832d86b6dcf32b308014