### PR TITLE
Fix user achievement progress mapping

### DIFF
--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -40,12 +40,10 @@ async function getUserAchievementsMap(userId) {
 // Get user's achievement progress (all achievements with unlock status)
 export async function getUserAchievementProgress(userId) {
   try {
-    const [allAchievements, userData] = await Promise.all([
+    const [allAchievements, userAchievements] = await Promise.all([
       getAllAchievements(),
       getUserAchievementsMap(userId)
     ]);
-
-    const userAchievements = userData?.achievements || {};
 
     return allAchievements.map(achievement => ({
       ...achievement,


### PR DESCRIPTION
## Summary
- fix `getUserAchievementProgress` to directly use the returned map from `getUserAchievementsMap`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cd1cb274c832d88df526df1f118a7