### PR TITLE
Fix profile completion achievement unlock

### DIFF
--- a/src/pages/app/Profile.jsx
+++ b/src/pages/app/Profile.jsx
@@ -73,7 +73,11 @@ const Profile = () => {
     setLoading(true);
     setError(""); 
     try {
-      await updateUserProfile({ ...form, dob: dob ? dob.toISOString().split("T")[0] : "" });
+      const { profileComplete, ...profileData } = form;
+      await updateUserProfile({
+        ...profileData,
+        dob: dob ? dob.toISOString().split("T")[0] : "",
+      });
       setEditMode(false);
       setSaved(true);
       setTimeout(() => setSaved(false), 1400);

--- a/src/pages/auth/CompleteProfile.jsx
+++ b/src/pages/auth/CompleteProfile.jsx
@@ -76,7 +76,6 @@ const CompleteProfile = () => {
     try {
       await updateUserProfile({
         ...updatedForm,
-        profileComplete: true,
       });
       setSaving(false);
       navigate("/dashboard");

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -16,7 +16,10 @@ export async function updateUserProfile(data) {
   const user = auth.currentUser;
   if (!user) throw new Error("No user logged in");
   const docRef = doc(db, "users", user.uid);
-  await updateDoc(docRef, data);
+
+  // Prevent external modification of the profileComplete flag
+  const { profileComplete, ...updateData } = data;
+  await updateDoc(docRef, updateData);
 
   const updatedSnap = await getDoc(docRef);
   if (updatedSnap.exists()) {


### PR DESCRIPTION
## Summary
- prevent callers from overriding `profileComplete` in `updateUserProfile`
- remove `profileComplete` flag from profile update forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cd2ddd990832d82f1495635fae6a9