### PR TITLE
Fix course achievement unlock logic

### DIFF
--- a/src/services/courseDetailService.js
+++ b/src/services/courseDetailService.js
@@ -16,8 +16,11 @@ export async function getCourseDetail(courseId) {
 
   const courseData = docSnap.data();
   const modules = Array.isArray(courseData.modules)
-    ? courseData.modules
-    : Object.values(courseData.modules || {});
+    ? courseData.modules.map((m, idx) => ({ id: m.id || String(idx), ...m }))
+    : Object.entries(courseData.modules || {}).map(([key, m]) => ({
+        id: m.id || key,
+        ...m,
+      }));
 
   return {
     id: docSnap.id,

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -7,8 +7,11 @@ export async function getCourses() {
   for (const docSnap of snapshot.docs) {
     const courseData = docSnap.data();
     const modules = Array.isArray(courseData.modules)
-      ? courseData.modules
-      : Object.values(courseData.modules || {});
+      ? courseData.modules.map((m, idx) => ({ id: m.id || String(idx), ...m }))
+      : Object.entries(courseData.modules || {}).map(([key, m]) => ({
+          id: m.id || key,
+          ...m,
+        }));
     courses.push({
       id: docSnap.id,
       ...courseData,


### PR DESCRIPTION
## Summary
- ensure each course module has a stable id

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cd8bbb4cc832d8a401a2c84137b1a