### PR TITLE
Fix first-course achievement trigger

### DIFF
--- a/src/pages/app/CourseDetail.jsx
+++ b/src/pages/app/CourseDetail.jsx
@@ -80,7 +80,7 @@ const CourseDetail = () => {
 
         const allCompleted = course.modules.every(
           (mod) =>
-            freshData[mod.id]?.lessonCompleted ||
+            freshData[mod.id]?.lessonCompleted &&
             freshData[mod.id]?.exerciseCompleted
         );
 
@@ -158,7 +158,7 @@ const CourseDetail = () => {
                           {/* Show checkmark if lesson or exercise has been completed */}
                           {completedMap &&
                             completedMap[chapter.module.id] &&
-                            (completedMap[chapter.module.id].lessonCompleted ||
+                            (completedMap[chapter.module.id].lessonCompleted &&
                               completedMap[chapter.module.id].exerciseCompleted) && (
                               <span className="text-green-400 font-bold">✔️</span>
                           )}

--- a/src/pages/app/Courses.jsx
+++ b/src/pages/app/Courses.jsx
@@ -34,7 +34,7 @@ const Courses = () => {
       modules.length > 0 &&
       modules.every(
         mod =>
-          progressForCourse[mod.id]?.lessonCompleted ||
+          progressForCourse[mod.id]?.lessonCompleted &&
           progressForCourse[mod.id]?.exerciseCompleted
       );
     return { ...course, completed };

--- a/src/pages/app/Dashboard.jsx
+++ b/src/pages/app/Dashboard.jsx
@@ -47,7 +47,7 @@ const Dashboard = () => {
 
     const completedModules = modules.filter(
       mod =>
-        progressForCourse[mod.id]?.lessonCompleted ||
+        progressForCourse[mod.id]?.lessonCompleted &&
         progressForCourse[mod.id]?.exerciseCompleted
     ).length;
 

--- a/src/pages/app/Profile.jsx
+++ b/src/pages/app/Profile.jsx
@@ -42,13 +42,13 @@ const Profile = () => {
           allCourses.forEach(course => {
             const modules = course.modules || [];
             const progress = allProgress[course.id] || {};
-            const allModulesCompleted =
-              modules.length > 0 &&
-              modules.every(
-                (mod) =>
-                  progress[mod.id]?.lessonCompleted ||
-                  progress[mod.id]?.exerciseCompleted
-              );
+              const allModulesCompleted =
+                modules.length > 0 &&
+                modules.every(
+                  (mod) =>
+                    progress[mod.id]?.lessonCompleted &&
+                    progress[mod.id]?.exerciseCompleted
+                );
             if (allModulesCompleted) count++;
           });
           setCompletedCourses(count);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -126,7 +126,7 @@ export async function completeCourse(userId, courseId, expReward = 50) {
     const progress = await getCompletedModules(userId, courseId);
     const allCompleted = course.modules.every(
       (mod) =>
-        progress[mod.id]?.lessonCompleted ||
+        progress[mod.id]?.lessonCompleted &&
         progress[mod.id]?.exerciseCompleted
     );
 


### PR DESCRIPTION
## Summary
- require both lesson and exercise to be completed for a module
- update course completion checks across the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d474a54e4832d9ad00fc0f39f3f53