### PR TITLE
Initialize achievements progress before subscription

### DIFF
--- a/src/pages/Achievements.jsx
+++ b/src/pages/Achievements.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react";
 import Navbar from "../components/Navbar";
-import { subscribeToUserAchievementProgress } from "../services/achievementService";
+import {
+  getUserAchievementProgress,
+  subscribeToUserAchievementProgress,
+} from "../services/achievementService";
 import { useAuth } from "../contexts/authContext";
 
 const AchievementPage = () => {
@@ -13,8 +16,21 @@ const AchievementPage = () => {
       return;
     }
 
-    const unsubscribe = subscribeToUserAchievementProgress(user.uid, setAchievementProgress);
-    return unsubscribe;
+    let unsubscribe;
+    const fetchAndSubscribe = async () => {
+      try {
+        const progress = await getUserAchievementProgress(user.uid);
+        setAchievementProgress(progress);
+      } catch (error) {
+        console.error("Error fetching initial achievement progress:", error);
+      }
+      unsubscribe = subscribeToUserAchievementProgress(user.uid, setAchievementProgress);
+    };
+
+    fetchAndSubscribe();
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
   }, [user]);
 
   // Split achievements into unlocked and locked


### PR DESCRIPTION
## Summary
- initialize progress via `getUserAchievementProgress` before subscribing for real-time updates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d4d7a4950832d9e16356698573e58