### PR TITLE
Enable user profile fetch by uid

### DIFF
--- a/src/pages/app/Profile.jsx
+++ b/src/pages/app/Profile.jsx
@@ -73,7 +73,7 @@ const Profile = () => {
     setLoading(true);
     setError(""); 
     try {
-      const { profileComplete, ...profileData } = form;
+      const { profileComplete: _profileComplete, ...profileData } = form;
       await updateUserProfile({
         ...profileData,
         dob: dob ? dob.toISOString().split("T")[0] : "",

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -4,10 +4,10 @@ import { checkCourseAchievements } from "./achievementService";
 import { getCourseDetail } from "./courseDetailService";
 import { getCompletedModules } from "./userProgressService";
 
-export async function getUserProfile() {
-  const user = auth.currentUser;
-  if (!user) return null;
-  const docRef = doc(db, "users", user.uid);
+export async function getUserProfile(uid) {
+  const userId = uid || auth.currentUser?.uid;
+  if (!userId) return null;
+  const docRef = doc(db, "users", userId);
   const docSnap = await getDoc(docRef);
   if (docSnap.exists()) {
     return docSnap.data();
@@ -21,7 +21,7 @@ export async function updateUserProfile(data) {
   const docRef = doc(db, "users", user.uid);
 
   // Prevent external modification of the profileComplete flag
-  const { profileComplete, ...updateData } = data;
+  const { profileComplete: _profileComplete, ...updateData } = data;
   await updateDoc(docRef, updateData);
 
   const updatedSnap = await getDoc(docRef);


### PR DESCRIPTION
## Summary
- allow `getUserProfile` to optionally accept a user id
- satisfy linter by ignoring `profileComplete` destructuring

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d512f486c832db09618870ffba4d9