### PR TITLE
fix course completion achievements

### DIFF
--- a/src/services/userProgressService.js
+++ b/src/services/userProgressService.js
@@ -1,6 +1,5 @@
 import { db } from "./firebase";
 import { doc, setDoc, getDoc, getDocs, collection } from "firebase/firestore";
-import { checkLessonAchievements } from "./achievementService";
 
 // Mark both lesson and exercise as completed
 export async function markModuleCompleted(userId, courseId, moduleId) {
@@ -13,7 +12,6 @@ export async function markModuleCompleted(userId, courseId, moduleId) {
     },
     { merge: true }
   );
-  await checkLessonAchievements(userId);
 }
 
 // Mark only the lesson portion as completed
@@ -26,7 +24,6 @@ export async function markLessonCompleted(userId, courseId, moduleId) {
     },
     { merge: true }
   );
-  await checkLessonAchievements(userId);
 }
 
 // Get all completed modules for a course for a user


### PR DESCRIPTION
## Summary
- prevent unlocking lesson achievement when modules complete

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d5481b4a4832d849436113f983dd9